### PR TITLE
style: Simplify parents' names in the group label

### DIFF
--- a/components/DashboardMemberList.tsx
+++ b/components/DashboardMemberList.tsx
@@ -418,7 +418,7 @@ export default function DashboardMemberList({
                                 )
                                 .filter(Boolean) as Person[];
                               const parentNames = parents
-                                .map((p) => p.full_name)
+                                .map((p) => p.full_name.trim().split(" ").splice(-2).join(" "))
                                 .join(" & ");
 
                               const label = parentNames


### PR DESCRIPTION
Tên của ba với mẹ lúc dài lúc ngắn, 3 chữ, 4 chữ hoặc 5 chữ. Trên mobile sẽ bị tràn khỏi cái group label
 
<img width="406" height="293" alt="before" src="https://github.com/user-attachments/assets/97f09849-835a-4417-99f1-fd1432de8281" />

Sau khi rút gọn, chỉ cần lấy 2 phần cuối, thường là chữ lót và tên thật
<img width="411" height="283" alt="after" src="https://github.com/user-attachments/assets/64b55498-588e-4a3d-a82e-1ceaa522c71c" />
